### PR TITLE
adds a pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+❗ Please **DO NOT** open a Pull Request without creating an Issue first. Failure to do so will result in the rejection of the pull request.
+
+## Purpose
+
+Please provide a detailed explanation of the PR. What existing problem does it solve?
+
+Fixes #[issue]
+
+
+## Changes
+
+Please provide an overview of code changes, especially key files and areas of significant change.
+
+
+## Steps to Reproduce or Test
+
+Demonstrate that the pull request is functional. For example: the exact commands to be run and their output; screenshots if the PR modifies the UI.
+
+
+## Optional GIF
+
+Self-explanatory.
+
+
+


### PR DESCRIPTION
❗ Please **DO NOT** open a Pull Request without creating an Issue first. Failure to do so will result in the rejection of the pull request.

## Purpose

This adds a PR template to make it easier to stay organized when review PR's.

Fixes #2

## Changes

.github/PULL_REQUEST_TEMPLATE.md
- this template will be use for new PR's when it's in the main


## Steps to Reproduce or Test

- verify that the file listed above is present.
